### PR TITLE
fix: unique keys issue in MovieListView

### DIFF
--- a/ex2.15/src/components/MovieListView.tsx
+++ b/ex2.15/src/components/MovieListView.tsx
@@ -11,7 +11,7 @@ const MovieListView = ({ movies }: MovieListViewProps) => {
     <div >
       <ul className="movie-list-view">
         {movies.map((movie) => (
-          <MovieCard key={movie.title} movie={movie} />
+          <MovieCard key={movie.id} movie={movie} />
         ))}
       </ul>
     </div>


### PR DESCRIPTION
There is nothing in the backend that prevents 2 movies from having similar titles. Therefore, we should use the id of a movie rather than its title as a key when mapping multiple movies.